### PR TITLE
Added video timestampts for stats with julia...

### DIFF
--- a/videos/Statistics-with-Julia-from-the-ground-up.md
+++ b/videos/Statistics-with-Julia-from-the-ground-up.md
@@ -1,0 +1,37 @@
+---
+Title: Statistics with Julia from the ground up | Workshop | JuliaCon 2021
+Speaker: Yoni Nazarathy
+Link: https://youtu.be/IlPoU5Yr2QI
+Code_Repo: https://github.com/yoninazarathy/JuliaCon2021-StatisticsWithJuliaFromTheGroundUp
+Related: 
+  - Title: Introduction to Julia with a focus on statistics (in Hebrew) | Yoni Nazarathy | JuliaCon 2022
+    Link: https://youtu.be/2Dn9XbqKfGo
+---
+
+0:00 Intro Music
+0:23 Welcome!
+0:52 Housekeeping and Installation Instructions
+4:10 Starting a Notebook
+7:14 Related Resources
+8:48 TOC and Workshop Setup
+17:14 Interlude for Questions
+18:06 Using the REPL
+21:44 Interlude for Questions
+22:17 Why Julia?
+24:29 Ways to Run Julia - Pluto, IDE...
+26:33 Key Resources
+30:50 Interlude for Questions
+34:43 What Do You `mean`? with Multiple Dispatch
+1:05:22 Interlude for Questions
+1:12:00 What Do You `mean`? with Broadcasting and Data Structures
+1:34:12 Interlude for Questions
+1:39:29 Something `rand` - The Monty Hall Problem
+2:01:23 Interlude for Questions
+2:07:38 Do You Still Miss R? So Just `RCall`
+2:13:24 Some `Plots` 
+2:34:48 Interlude for Questions
+2:40:53 Examples - Union Types, Basic Inference...
+2:57:57 Conclusion and Final Questions
+2:59:43 Outro Music
+
+> :warning: "Your favourite `Distribution`", "We love `DataFrames`", "Basic Machine learning" were not covered; sections 8 and 9 were briefly shown in the examples near the end


### PR DESCRIPTION
Added video timestamps for "Statistics with Julia from the ground up | Workshop | JuliaCon 2021"

I'm not sure exactly how you process these to add them to YouTube so I thought I'd make a quick note about the Yaml Frontmatter format that I've used. It is often used in markdown files to add meta-data and then processed with [grey-matter](https://github.com/jonschlinkert/gray-matter).

Issue #186 