### PR TITLE
Added Timestamps for Interactive data visualizations with makie

### DIFF
--- a/videos/Interactive-data-visualizations-with-Makie.md
+++ b/videos/Interactive-data-visualizations-with-Makie.md
@@ -1,0 +1,52 @@
+---
+title: Interactive data visualizations with Makie.jl | Simon Danisch & Julius Krumbiegel | JuliaCon 2022
+link: https://youtu.be/VT1XY1-fNlY
+speakers:
+  - Simon Danisch
+  - Julius Krumbiegel
+date: 23-07-2022
+package: https://juliapackages.com/p/makie
+repo: https://github.com/jkrumbiegel/JuliaCon2022Makie
+docs: https://makie.juliaplots.org/stable/
+examples: https://github.com/lazarusA/100daysOfMakie
+abstract: |
+    Makie.jl is a Julia-native interactive data visualization library. In this workshop, participants will learn how to create complex interactive and static plots, using the full range of tools Makie has to offer. Topics could include writing custom recipes, understanding the scene graph, mastering the layout system, handling complex observable structures and tweaking visual styles. The workshop will also be an opportunity to learn about the architecture and underlying ideas of Makie.
+description: |
+    The participants will follow along while different small interactive visualization projects are coded live, showing how to go from idea to implementation.
+related:
+  - title: A deep dive into MakieLayout | Julius Krumbiegel | JuliaCon2021
+    link: https://youtu.be/AtqXFfaMZqo
+---
+
+Makie.jl is a Julia-native interactive data visualization library. In this workshop, participants will learn how to create complex interactive and static plots, using the full range of tools Makie has to offer. Topics could include writing custom recipes, understanding the scene graph, mastering the layout system, handling complex observable structures and tweaking visual styles. The workshop will also be an opportunity to learn about the architecture and underlying ideas of Makie.
+
+The code for this workshop is available at https://github.com/jkrumbiegel/JuliaCon2022Makie
+
+The documentation can currently be found at https://makie.juliaplots.org
+
+View the Makie Blog for future developments https://blog.makie.org/
+
+0:00 - Intro Music
+0:31 - Agenda
+2:01 - What is Makie
+3:50 - Sponsors and Funding Makie
+9:33 - Move to MakieOrg
+12:39 - Backends and Makie's Building Blocks
+17:10 - Scenes in Makie
+19:04 - Creating a Makie System Image with PackageCompiler.jl
+24:39 - Finding Documentation
+36:59 - Basic Building Blocks
+48:00 - Layouts
+1:08:12 - Theming
+1:10:27 - How Layouts Respond to Plot Decorations
+1:18:27 - Aspect Ratios
+1:24:16 - Break
+1:29:27 - Questions
+1:32:20 - Recipes
+1:43:40 - Interactions
+2:04:25 - Questions
+2:08:59 - Sizes and Units
+2:20:02 - Interactive App Example
+2:38:45 - Wrap Up and Final Questions
+
+S/o to https://github.com/Andy2K11 for the video timestamps!

--- a/videos/Interactive-data-visualizations-with-Makie.md
+++ b/videos/Interactive-data-visualizations-with-Makie.md
@@ -26,27 +26,27 @@ The documentation can currently be found at https://makie.juliaplots.org
 
 View the Makie Blog for future developments https://blog.makie.org/
 
-0:00 - Intro Music
-0:31 - Agenda
-2:01 - What is Makie
-3:50 - Sponsors and Funding Makie
-9:33 - Move to MakieOrg
-12:39 - Backends and Makie's Building Blocks
-17:10 - Scenes in Makie
-19:04 - Creating a Makie System Image with PackageCompiler.jl
-24:39 - Finding Documentation
-36:59 - Basic Building Blocks
-48:00 - Layouts
-1:08:12 - Theming
-1:10:27 - How Layouts Respond to Plot Decorations
-1:18:27 - Aspect Ratios
-1:24:16 - Break
-1:29:27 - Questions
-1:32:20 - Recipes
-1:43:40 - Interactions
-2:04:25 - Questions
-2:08:59 - Sizes and Units
-2:20:02 - Interactive App Example
-2:38:45 - Wrap Up and Final Questions
+00:00:00 - Intro Music
+00:00:31 - Agenda
+00:02:01 - What is Makie
+00:03:50 - Sponsors and Funding Makie
+00:09:33 - Move to MakieOrg
+00:12:39 - Backends and Makie's Building Blocks
+00:17:10 - Scenes in Makie
+00:19:04 - Creating a Makie System Image with PackageCompiler.jl
+00:24:39 - Finding Documentation
+00:36:59 - Basic Building Blocks
+00:48:00 - Layouts
+01:08:12 - Theming
+01:10:27 - How Layouts Respond to Plot Decorations
+01:18:27 - Aspect Ratios
+01:24:16 - Break
+01:29:27 - Questions
+01:32:20 - Recipes
+01:43:40 - Interactions
+02:04:25 - Questions
+02:08:59 - Sizes and Units
+02:20:02 - Interactive App Example
+02:38:45 - Wrap Up and Final Questions
 
 S/o to https://github.com/Andy2K11 for the video timestamps!


### PR DESCRIPTION
# Timestamps for Interactive data visualizations with Makie.jl

Issue #188 

Included is a suggested description for the video which may be a bit more informative for viewers watching after the live event.

Will add the timestamps *without* zero padding to the issue, I don't know which style you prefer but, I imagine it's not on the top of your priority list either way.