### PR TITLE
Add timestamps for JuliaSyntax.jl JuliaCon 2022 talk

### DIFF
--- a/videos/JuliaSyntax_A_new_Julia_compiler_frontend_in_Julia.md
+++ b/videos/JuliaSyntax_A_new_Julia_compiler_frontend_in_Julia.md
@@ -1,0 +1,15 @@
+References:
+Video title: JuliaSyntax.jl: A new Julia compiler frontend in Julia | Chris Foster | JuliaCon 2022
+Link: https://www.youtube.com/watch?v=CIiGng9Brrk
+Link to the code: https://github.com/JuliaLang/JuliaSyntax.jl
+
+Contents:
+0:00 Welcome
+0:23 Motivation and Demo
+4:35 Compiler Frontend Overview
+6:22 Lossless Parsing
+10:34 Green Trees
+13:20 Streaming Parsers
+18:28 Example Streaming Parser
+23:01 Project Status and Future
+24:30 Thanks and Goodbye


### PR DESCRIPTION
Here's timestamps for my talk for this year.

I've already contributed captions for this separately.